### PR TITLE
Use dependabot to manage ko version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
   schedule:
     interval: daily
 - package-ecosystem: gomod
+  directory: "/hack/ko"
+  schedule:
+    interval: daily
+- package-ecosystem: gomod
   directory: "/hack/kustomize"
   schedule:
     interval: daily


### PR DESCRIPTION
This is fixing a previous oversight